### PR TITLE
Fix #1: Ignore entries which are within comments

### DIFF
--- a/collection/SAMPLE_ONE.js
+++ b/collection/SAMPLE_ONE.js
@@ -24,6 +24,7 @@ exchangeCode = async (req, res, next) => {
       url: "https://accounts.google.com/o/oauth2/token",
       json: true,
       form: {
+	// replaced process.env.GOOGLE_ID for sematic purposes
         client_id: process.env.GOOGLE_CLIENT_ID,
         client_secret: process.env.GOOGLE_CLIENT_SECRET,
         grant_type: "authorization_code",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "env-example-generator",
+  "name": "@hackcode/env-example-generator",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -18,6 +18,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/strip-comments": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-comments/-/strip-comments-2.0.0.tgz",
+      "integrity": "sha512-B0PNDZ+50qubrXFZsLN+DVnJdSqv1u80YiLIZuFmrtmf/yC57R2C2S3fUjsuqjFuFcu2kCNOoImVhXNK/+xBvQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -53,6 +59,11 @@
       "requires": {
         "minimatch": "3.0.4"
       }
+    },
+    "strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
     },
     "typescript": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   "devDependencies": {
     "@types/node": "^14.11.2",
     "@types/recursive-readdir": "^2.2.0",
+    "@types/strip-comments": "^2.0.0",
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "recursive-readdir": "^2.2.2"
+    "recursive-readdir": "^2.2.2",
+    "strip-comments": "^2.0.1"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import recursive from 'recursive-readdir'
 
 /** include auxillary functions */
-import { Filter, extractWordsFrom, extractKeysFrom, writeDataToEnv } from './aux'
+import { Filter, extractWordsFrom, extractKeysFrom, writeDataToEnv, stripComments } from './aux'
 
 /** main function runner */
 const worker = async () => {
@@ -12,7 +12,8 @@ const worker = async () => {
   let words: Array<string> = []
   for (let i = 0; i < files.length; i += 1) {
     const data = await fs.readFileSync(files[i], 'utf8')
-    extractWordsFrom(data).forEach((word) => words.push(word))
+    const strippedData = stripComments(data)
+    extractWordsFrom(strippedData).forEach((word) => words.push(word))
   }
   const keys: Array<string> = extractKeysFrom(words)
   writeDataToEnv(keys)

--- a/src/aux.ts
+++ b/src/aux.ts
@@ -1,6 +1,12 @@
 import fs from 'fs'
+import strip from 'strip-comments'
 
 export const Filter: string[] = ['!*.{ts,js,jsx}', 'node_modules/*']
+
+export const stripComments = (data: string): string => {
+  const strippedData = strip(data)
+  return strippedData
+}
 
 export const extractWordsFrom = (data: string): Array<string> => {
   const regexMatches: RegExpMatchArray = data.match(/process.env.\s*([^\W]*)/gi) || []


### PR DESCRIPTION
Fixes #1 
Strip comments using `strip-comments` package before regex matching.

## Verifying fix
Generate env for `SAMPLE_ONE.js` and it should not contain key `GOOGLE_ID`